### PR TITLE
docs: clarify return type for to* functions

### DIFF
--- a/packages/filecoin-number/readme.md
+++ b/packages/filecoin-number/readme.md
@@ -13,7 +13,7 @@ const filecoinNumber = new FilecoinNumber('10000', 'attofil')
 // filecoinNumber is an instance of BigNumber, so you can use it as such
 filecoinNumber.multiply(7)
 
-// it comes with 2 additional instance methods for showing the filecoin number in attofil or fil
+// it comes with 2 additional instance methods for showing the filecoin number as a string in attofil or fil
 const inPicoFil = filecoinNumber.toPicoFil()
 const inAttoFil = filecoinNumber.toAttoFil()
 const inFil = filecoinNumber.toFil()


### PR DESCRIPTION
There's no real docs so explicitly stating the return type in the comment in the example will help.

(When I first came to this I did not realise they were all converted to fil when created so thought that you needed to convert between an fil/attofil "number").