### PR TITLE
feat: add toString method to Address

### DIFF
--- a/packages/filecoin-address/src/__tests__/address.spec.ts
+++ b/packages/filecoin-address/src/__tests__/address.spec.ts
@@ -5,7 +5,7 @@ import {
   IDAddresses,
   secp256k1Addresses
 } from './constants'
-import { encode, newFromString, validateAddressString, newIDAddress } from '../index'
+import { encode, newFromString, validateAddressString, newIDAddress, setCurrentNetwork, Network } from '../index'
 
 describe('address', () => {
   describe('newIDAddress', () => {
@@ -94,6 +94,48 @@ describe('address', () => {
     test('it should encode an Actor address', async () => {
       const address = newFromString(actorAddresses[0].string)
       expect(encode('t', address)).toBe(actorAddresses[0].string)
+    })
+  })
+
+  describe('toString', () => {
+    test('it should stringify ID addresses', async () => {
+      IDAddresses.forEach(item => {
+        const address = newFromString(item.string)
+        setCurrentNetwork(Network.TEST)
+        expect(`${address}`).toBe(`${Network.TEST}${item.string.slice(1)}`)
+        setCurrentNetwork(Network.MAIN)
+        expect(`${address}`).toBe(`${Network.MAIN}${item.string.slice(1)}`)
+      })
+    })
+
+    test('it should stringify secp256k1 addresses', async () => {
+      secp256k1Addresses.forEach(item => {
+        const address = newFromString(item.string)
+        setCurrentNetwork(Network.TEST)
+        expect(`${address}`).toBe(`${Network.TEST}${item.string.slice(1)}`)
+        setCurrentNetwork(Network.MAIN)
+        expect(`${address}`).toBe(`${Network.MAIN}${item.string.slice(1)}`)
+      })
+    })
+
+    test('it should stringify BLS addresses', async () => {
+      BLSAddresses.forEach(item => {
+        const address = newFromString(item.string)
+        setCurrentNetwork(Network.TEST)
+        expect(`${address}`).toBe(`${Network.TEST}${item.string.slice(1)}`)
+        setCurrentNetwork(Network.MAIN)
+        expect(`${address}`).toBe(`${Network.MAIN}${item.string.slice(1)}`)
+      })
+    })
+
+    test('it should stringify Actor addresses', async () => {
+      actorAddresses.forEach(item => {
+        const address = newFromString(item.string)
+        setCurrentNetwork(Network.TEST)
+        expect(`${address}`).toBe(`${Network.TEST}${item.string.slice(1)}`)
+        setCurrentNetwork(Network.MAIN)
+        expect(`${address}`).toBe(`${Network.MAIN}${item.string.slice(1)}`)
+      })
     })
   })
 

--- a/packages/filecoin-address/src/index.ts
+++ b/packages/filecoin-address/src/index.ts
@@ -33,6 +33,16 @@ export class Address {
     return this.str.slice(1, this.str.length)
   }
 
+  /**
+   * toString returns a string representation of this address. Prefixed with the
+   * locally defined "currentNetwork" variable. By default this is the mainnet
+   * prefix "f". The "currentNetwork" can be changed by calling the exported 
+   * "setCurrentNetwork" function.
+   * 
+   * Warning: any code with access to this module can call "setCurrentNetwork"
+   * so prefer the exported "encode" function for any string representation of
+   * this address that is mission critical.
+   */
   toString(): string {
     return encode(currentNetwork, this)
   }

--- a/packages/filecoin-address/src/index.ts
+++ b/packages/filecoin-address/src/index.ts
@@ -10,6 +10,8 @@ export * from './protocol'
 
 const base32 = base32Function('abcdefghijklmnopqrstuvwxyz234567')
 
+let currentNetwork = Network.MAIN
+
 export class Address {
   readonly str: Uint8Array
   readonly _protocol: Protocol
@@ -29,6 +31,10 @@ export class Address {
 
   payload(): Uint8Array {
     return this.str.slice(1, this.str.length)
+  }
+
+  toString(): string {
+    return encode(currentNetwork, this)
   }
 }
 
@@ -152,6 +158,10 @@ export function checkAddressString(address: string) {
   }
 }
 
+export function setCurrentNetwork (network: Network) {
+  currentNetwork = network
+}
+
 export default {
   Address,
   newAddress,
@@ -164,6 +174,7 @@ export default {
   validateChecksum,
   validateAddressString,
   checkAddressString,
+  setCurrentNetwork,
   Network,
   Protocol
 }


### PR DESCRIPTION
This adds a `toString` method to `Address` that calls `encode` with a `currentNetwork` variable defined in the module.

It allows module consumers to call `address.toString()` or use the address directly in a template string (`` `${address}` ``) or as part of string concatination (`'Address: ' + address`). It's a convenient alternative to using the `encode` function.

It also adds a `setCurrentNetwork` export that allows a consumer to change the current network.

The API is a little clunky but is consistent with the [`go-address` implementation](https://github.com/filecoin-project/go-address/blob/f2023ef3f5bbc513599a3fbf19c4770485146a07/address.go#L97-L104), the difference is just that by default the current network is mainnet "f" and the exported `setCurrentNetwork` function which is required due to javascript and modules.