### PR TITLE
feat: add equals method

### DIFF
--- a/packages/filecoin-address/README.md
+++ b/packages/filecoin-address/README.md
@@ -14,7 +14,7 @@ const { newFromString, encode } = require('@glif/filecoin-address')
 const address = newFromString('t1hvuzpfdycc6z6mjgbiyaiojikd6wk2vwy7muuei')
 const addressProtocol = address.protocol()
 const addressPayload = address.payload()
-const addressString = address.str
+const addressString = address.str // Uint8Array
 
 const networkPrefix = 't'
 const encoded = encode(networkPrefix, address)
@@ -23,9 +23,11 @@ const encoded = encode(networkPrefix, address)
 #### Exported methods
 
 - newAddress
+- newIDAddress
 - newFromString
 - decode
 - encode
+- equals
 - bigintToArray
 - getChecksum
 - validateChecksum

--- a/packages/filecoin-address/src/__tests__/address.spec.ts
+++ b/packages/filecoin-address/src/__tests__/address.spec.ts
@@ -151,6 +151,28 @@ describe('address', () => {
     })
   })
 
+  describe('equals', () => {
+    test('it should be equal if it is the same instance', () => {
+      const address = new Address(IDAddresses[0].decodedByteArray)
+      expect(address === address).toBe(true)
+      expect(address.equals(address)).toBe(true)
+    })
+
+    test('it should be equal if they have the same value', () => {
+      const address0 = new Address(IDAddresses[0].decodedByteArray)
+      const address1 = new Address(IDAddresses[0].decodedByteArray)
+      expect(address0 === address1).toBe(false)
+      expect(address0.equals(address1)).toBe(true)
+    })
+
+    test('it should not be equal if they do not have the same value', () => {
+      const address0 = new Address(IDAddresses[0].decodedByteArray)
+      const address1 = new Address(IDAddresses[1].decodedByteArray)
+      expect(address0 === address1).toBe(false)
+      expect(address0.equals(address1)).toBe(false)
+    })
+  })
+
   describe('validateAddressString', () => {
     test("it should invalidate address that's too short", async () => {
       expect(validateAddressString('t0')).toBe(false)

--- a/packages/filecoin-address/src/index.ts
+++ b/packages/filecoin-address/src/index.ts
@@ -46,6 +46,18 @@ export class Address {
   toString (): string {
     return encode(this._network, this)
   }
+
+  /**
+   * equals determines if this address is the "same" address as the passed
+   * address. Two addresses are considered equal if they are the same instance
+   * OR if their "str" property matches byte for byte.
+   */
+  equals (addr: Address): boolean {
+    if (this === addr) {
+      return true
+    }
+    return uint8arrays.equals(this.str, addr.str)
+  }
 }
 
 export function bigintToArray(v: string | BigInt | number): Uint8Array {


### PR DESCRIPTION
`equals` determines if an address is the "same" address as a passed address. Two addresses are considered equal if they are the same instance OR if their "str" property matches byte for byte.

