### PR TITLE
Do not use gas limit to compare msg gas params

### DIFF
--- a/packages/filecoin-wallet-provider/src/filecoin.ts
+++ b/packages/filecoin-wallet-provider/src/filecoin.ts
@@ -289,8 +289,7 @@ export class Filecoin {
 
     const takeMin =
       recommendedMessage.gasFeeCap.isLessThan(minGasFeeCap) ||
-      recommendedMessage.gasPremium.isLessThan(minGasPremium) ||
-      recommendedMessage.gasLimit < minGasLimit
+      recommendedMessage.gasPremium.isLessThan(minGasPremium)
 
     return {
       gasFeeCap: takeMin
@@ -299,7 +298,7 @@ export class Filecoin {
       gasPremium: takeMin
         ? minGasPremium
         : recommendedMessage.gasPremium.toString(),
-      gasLimit: takeMin ? minGasLimit : recommendedMessage.gasLimit,
+      gasLimit: recommendedMessage.gasLimit,
     }
   }
 


### PR DESCRIPTION
From one of the lead lotus devs

<img width="513" alt="image" src="https://user-images.githubusercontent.com/12353734/181154094-c75695d3-21b5-4e95-97ae-abb0f6809afd.png">
